### PR TITLE
Updated bcrypt version to resolve node-gyp installation errors

### DIFF
--- a/conduit/package-lock.json
+++ b/conduit/package-lock.json
@@ -19,9 +19,9 @@
       "integrity": "sha1-7ySTFDLwYVXnvDnNuKaze0oos9A=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
       }
     },
     "abab": {
@@ -42,7 +42,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-jsx": {
@@ -51,7 +51,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "^5.0.3"
       }
     },
     "ajv": {
@@ -60,10 +60,10 @@
       "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.1"
       }
     },
     "ajv-keywords": {
@@ -78,9 +78,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -95,7 +95,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -116,8 +116,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -126,7 +126,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -149,7 +149,7 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -158,8 +158,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "append-transform": {
@@ -168,7 +168,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "2.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "argparse": {
@@ -177,14 +177,13 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "args": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/args/-/args-5.0.0.tgz",
       "integrity": "sha512-eCZo33yLdQ3DiG/Ko5n11uPonyYofYd9F2cqWID8TKGZwK/Z2ZcUj/oZ1HNMeNL2lgraPnv3JBZumfbUMqmZtg==",
-      "dev": true,
       "requires": {
         "camelcase": "5.0.0",
         "chalk": "2.4.1",
@@ -196,41 +195,36 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "camelcase": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-          "dev": true
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -271,7 +265,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -357,9 +351,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -374,11 +368,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -395,25 +389,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       }
     },
     "babel-generator": {
@@ -422,14 +416,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helpers": {
@@ -438,8 +432,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -448,8 +442,8 @@
       "integrity": "sha1-FKnWo/QSLf6mBp03CFrfJqU6Tbo=",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "4.1.6",
-        "babel-preset-jest": "23.2.0"
+        "babel-plugin-istanbul": "^4.1.6",
+        "babel-preset-jest": "^23.2.0"
       }
     },
     "babel-messages": {
@@ -458,7 +452,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -467,10 +461,10 @@
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "test-exclude": "4.2.1"
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "test-exclude": "^4.2.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -491,9 +485,9 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.10.5"
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -510,8 +504,8 @@
       "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "23.2.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+        "babel-plugin-jest-hoist": "^23.2.0",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
     "babel-register": {
@@ -520,13 +514,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.3",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -535,8 +529,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -545,11 +539,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -558,15 +552,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "globals": {
@@ -583,10 +577,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -598,8 +592,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -607,13 +600,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -622,7 +615,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -631,7 +624,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -640,7 +633,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -649,9 +642,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -663,12 +656,12 @@
       }
     },
     "bcrypt": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-2.0.1.tgz",
-      "integrity": "sha512-DwB7WgJPdskbR+9Y3OTJtwRq09Lmm7Na6b+4ewvXjkD0nfNRi1OozxljHm5ETlDCBq9DTy04lQz+rj+T2ztIJg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-3.0.2.tgz",
+      "integrity": "sha512-kE1IaaRchCgdrmzQX/eBQKcsuL4jRHZ+O11sMvEUrI/HgFTQYAGvxlj9z7kb3zfFuwljQ5y8/NrbnXtgx5oJLg==",
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "nan": "2.11.1",
+        "node-pre-gyp": "0.11.0"
       },
       "dependencies": {
         "abbrev": {
@@ -684,11 +677,11 @@
           "bundled": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.5"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -699,12 +692,12 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true
         },
         "code-point-at": {
@@ -731,7 +724,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.6.0",
           "bundled": true
         },
         "delegates": {
@@ -746,7 +739,7 @@
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -757,26 +750,26 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -784,25 +777,25 @@
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -817,7 +810,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -828,7 +821,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -836,13 +829,17 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.4",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           },
           "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
             "yallist": {
               "version": "3.0.2",
               "bundled": true
@@ -853,7 +850,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -867,59 +864,64 @@
           "version": "2.0.0",
           "bundled": true
         },
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+        },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.3",
           "bundled": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.11.0",
           "bundled": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -934,7 +936,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -949,8 +951,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -962,13 +964,13 @@
           "bundled": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -981,20 +983,20 @@
           "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -1010,7 +1012,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.5.1",
           "bundled": true
         },
         "set-blocking": {
@@ -1025,23 +1027,23 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -1049,18 +1051,22 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.6",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.3",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
             "yallist": {
               "version": "3.0.2",
               "bundled": true
@@ -1072,10 +1078,10 @@
           "bundled": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -1091,7 +1097,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-search-tree": {
@@ -1099,7 +1105,7 @@
       "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
       "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
       "requires": {
-        "underscore": "1.4.4"
+        "underscore": "~1.4.4"
       }
     },
     "bluebird": {
@@ -1113,15 +1119,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
@@ -1129,7 +1135,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -1140,13 +1146,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.0",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1173,8 +1179,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1183,7 +1189,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -1192,9 +1198,8 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1204,16 +1209,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.2",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1222,7 +1227,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -1248,7 +1253,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "bson": {
@@ -1284,15 +1289,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "caller-path": {
@@ -1301,7 +1306,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsite": {
@@ -1316,12 +1321,12 @@
       "integrity": "sha1-mgOQZC5D/ou4I5ReUUZPafQWQ94=",
       "dev": true,
       "requires": {
-        "callsite": "1.0.0",
-        "chalk": "1.1.3",
-        "error-stack-parser": "1.3.6",
-        "highlight-es": "1.0.3",
-        "lodash": "4.17.10",
-        "pinkie-promise": "2.0.1"
+        "callsite": "^1.0.0",
+        "chalk": "^1.1.1",
+        "error-stack-parser": "^1.3.3",
+        "highlight-es": "^1.0.0",
+        "lodash": "4.6.1 || ^4.16.1",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1336,11 +1341,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -1370,8 +1375,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -1388,7 +1393,7 @@
       "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
       "dev": true,
       "requires": {
-        "rsvp": "3.6.2"
+        "rsvp": "^3.3.3"
       }
     },
     "capture-stack-trace": {
@@ -1410,8 +1415,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -1420,9 +1425,9 @@
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       }
     },
     "chardet": {
@@ -1449,10 +1454,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1461,7 +1466,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -1478,10 +1483,10 @@
       "integrity": "sha1-dfpfcowwjMSsWUsF4GzF2A2szYY=",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.45",
-        "memoizee": "0.3.10",
-        "timers-ext": "0.1.5"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.2",
+        "memoizee": "0.3.x",
+        "timers-ext": "0.1.x"
       }
     },
     "cli-cursor": {
@@ -1490,7 +1495,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-spinners": {
@@ -1512,8 +1517,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -1570,8 +1575,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -1579,7 +1584,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -1593,7 +1598,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "compare-versions": {
@@ -1611,8 +1616,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
       "version": "3.1.2",
@@ -1620,12 +1624,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "content-type": {
@@ -1663,7 +1667,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -1672,9 +1676,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cross-spawn-async": {
@@ -1683,8 +1687,8 @@
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
       }
     },
     "crypto-random-string": {
@@ -1705,7 +1709,7 @@
       "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.4"
+        "cssom": "0.3.x"
       }
     },
     "currently-unhandled": {
@@ -1714,7 +1718,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "d": {
@@ -1723,7 +1727,7 @@
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.45"
+        "es5-ext": "~0.10.2"
       }
     },
     "dashdash": {
@@ -1732,7 +1736,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-urls": {
@@ -1741,9 +1745,9 @@
       "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.5.0"
+        "abab": "^1.0.4",
+        "whatwg-mimetype": "^2.0.0",
+        "whatwg-url": "^6.4.0"
       }
     },
     "debug": {
@@ -1784,7 +1788,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "3.0.0"
+        "strip-bom": "^3.0.0"
       }
     },
     "defaults": {
@@ -1793,7 +1797,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       }
     },
     "define-properties": {
@@ -1802,8 +1806,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "define-property": {
@@ -1812,8 +1816,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1822,7 +1826,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -1831,7 +1835,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -1840,9 +1844,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -1859,13 +1863,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -1885,17 +1889,17 @@
       "integrity": "sha1-7+b99c8AwhcoEbwqJAPVnlNB5Rk=",
       "dev": true,
       "requires": {
-        "babel-traverse": "6.26.0",
-        "babylon": "6.18.0",
-        "builtin-modules": "1.1.1",
-        "deprecate": "1.0.0",
-        "deps-regex": "0.1.4",
-        "js-yaml": "3.11.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "require-package-name": "2.0.1",
+        "babel-traverse": "^6.7.3",
+        "babylon": "^6.1.21",
+        "builtin-modules": "^1.1.1",
+        "deprecate": "^1.0.0",
+        "deps-regex": "^0.1.4",
+        "js-yaml": "^3.4.2",
+        "lodash": "^4.5.1",
+        "minimatch": "^3.0.2",
+        "require-package-name": "^2.0.1",
         "walkdir": "0.0.11",
-        "yargs": "8.0.2"
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1916,9 +1920,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -1927,9 +1931,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -1940,10 +1944,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
@@ -1952,7 +1956,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -1961,9 +1965,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -1972,8 +1976,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -1982,8 +1986,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -1998,7 +2002,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -2009,19 +2013,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         },
         "yargs-parser": {
@@ -2030,7 +2034,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -2063,7 +2067,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-newline": {
@@ -2084,7 +2088,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "domexception": {
@@ -2093,7 +2097,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "4.0.2"
+        "webidl-conversions": "^4.0.2"
       }
     },
     "dot-prop": {
@@ -2102,7 +2106,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer3": {
@@ -2118,7 +2122,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -2126,7 +2130,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -2145,7 +2149,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "error-stack-parser": {
@@ -2154,7 +2158,7 @@
       "integrity": "sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=",
       "dev": true,
       "requires": {
-        "stackframe": "0.3.1"
+        "stackframe": "^0.3.1"
       }
     },
     "es-abstract": {
@@ -2163,11 +2167,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -2176,9 +2180,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -2187,9 +2191,9 @@
       "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-error": {
@@ -2203,9 +2207,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       },
       "dependencies": {
         "d": {
@@ -2214,7 +2218,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.45"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -2225,8 +2229,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       },
       "dependencies": {
         "d": {
@@ -2235,7 +2239,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.45"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -2246,10 +2250,10 @@
       "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.45",
-        "es6-iterator": "0.1.3",
-        "es6-symbol": "2.0.1"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.6",
+        "es6-iterator": "~0.1.3",
+        "es6-symbol": "~2.0.1"
       },
       "dependencies": {
         "es6-iterator": {
@@ -2258,9 +2262,9 @@
           "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.45",
-            "es6-symbol": "2.0.1"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.5",
+            "es6-symbol": "~2.0.1"
           }
         },
         "es6-symbol": {
@@ -2269,8 +2273,8 @@
           "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
           "dev": true,
           "requires": {
-            "d": "0.1.1",
-            "es5-ext": "0.10.45"
+            "d": "~0.1.1",
+            "es5-ext": "~0.10.5"
           }
         }
       }
@@ -2291,11 +2295,11 @@
       "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -2319,44 +2323,44 @@
       "integrity": "sha512-D5nG2rErquLUstgUaxJlWB5+gu+U/3VDY0fk/Iuq8y9CUFy/7Y6oF4N2cR1tV8knzQvciIbfqfohd359xTLIKQ==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.0",
-        "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "4.0.0",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "4.0.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.7.0",
-        "ignore": "3.3.10",
-        "imurmurhash": "0.1.4",
-        "inquirer": "5.2.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "string.prototype.matchall": "2.0.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.3",
-        "text-table": "0.2.0"
+        "ajv": "^6.5.0",
+        "babel-code-frame": "^6.26.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.5.0",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^5.2.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.11.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.1.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.0",
+        "string.prototype.matchall": "^2.0.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^4.0.3",
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2371,11 +2375,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.0"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -2393,7 +2397,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -2404,8 +2408,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -2420,8 +2424,8 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1",
-        "acorn-jsx": "4.1.1"
+        "acorn": "^5.6.0",
+        "acorn-jsx": "^4.1.1"
       }
     },
     "esprima": {
@@ -2436,7 +2440,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -2445,7 +2449,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -2471,8 +2475,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.45"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       },
       "dependencies": {
         "d": {
@@ -2481,7 +2485,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.45"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -2489,8 +2493,7 @@
     "eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-      "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI=",
-      "dev": true
+      "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
     },
     "exec-sh": {
       "version": "0.2.2",
@@ -2498,7 +2501,7 @@
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.2.0"
       }
     },
     "execa": {
@@ -2507,13 +2510,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit": {
@@ -2534,13 +2537,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -2549,7 +2552,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -2558,7 +2561,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2569,7 +2572,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "expect": {
@@ -2578,12 +2581,12 @@
       "integrity": "sha1-7LBRrcvcQKxNtXbBYGfxL9sTzGE=",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "jest-diff": "23.2.0",
-        "jest-get-type": "22.4.3",
-        "jest-matcher-utils": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-regex-util": "23.3.0"
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^23.2.0",
+        "jest-get-type": "^22.1.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-regex-util": "^23.3.0"
       }
     },
     "extend": {
@@ -2598,8 +2601,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2608,7 +2611,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -2619,9 +2622,9 @@
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -2630,14 +2633,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -2646,7 +2649,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -2655,7 +2658,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2664,7 +2667,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2673,7 +2676,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2682,9 +2685,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -2722,8 +2725,7 @@
     "fastest-validator": {
       "version": "0.6.10",
       "resolved": "https://registry.npmjs.org/fastest-validator/-/fastest-validator-0.6.10.tgz",
-      "integrity": "sha512-vef5q97XgY3RWUPGDmt/y0Brxuig/mg1Hctl1BG5roPMVeEiSzaGbSPPPNELGxUkDmAzmhS1f0I7aSxqSu2vzQ==",
-      "dev": true
+      "integrity": "sha512-vef5q97XgY3RWUPGDmt/y0Brxuig/mg1Hctl1BG5roPMVeEiSzaGbSPPPNELGxUkDmAzmhS1f0I7aSxqSu2vzQ=="
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -2731,7 +2733,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "figures": {
@@ -2740,7 +2742,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2749,8 +2751,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "fileset": {
@@ -2759,8 +2761,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -2769,10 +2771,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2781,7 +2783,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2792,7 +2794,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -2801,10 +2803,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flexbuffer": {
@@ -2836,9 +2838,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fragment-cache": {
@@ -2847,7 +2849,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -2858,8 +2860,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -2868,8 +2869,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2895,8 +2896,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -2909,7 +2910,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2973,7 +2974,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -2988,14 +2989,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -3004,12 +3005,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -3024,7 +3025,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -3033,7 +3034,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -3042,8 +3043,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3062,7 +3063,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -3076,7 +3077,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -3089,8 +3090,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -3099,7 +3100,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -3122,9 +3123,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -3133,16 +3134,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -3151,8 +3152,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -3167,8 +3168,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3177,10 +3178,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -3199,7 +3200,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -3220,8 +3221,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -3242,10 +3243,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -3262,13 +3263,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -3277,7 +3278,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -3320,9 +3321,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -3331,7 +3332,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -3339,7 +3340,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -3354,13 +3355,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -3375,7 +3376,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3432,7 +3433,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "giturl": {
@@ -3445,14 +3446,13 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global-dirs": {
@@ -3461,7 +3461,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "1.3.5"
+        "ini": "^1.3.4"
       }
     },
     "global-modules": {
@@ -3470,9 +3470,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -3481,11 +3481,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -3500,12 +3500,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "got": {
@@ -3514,17 +3514,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -3545,10 +3545,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -3563,7 +3563,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -3580,8 +3580,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -3590,10 +3590,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "fast-deep-equal": {
@@ -3616,7 +3616,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -3625,7 +3625,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -3646,9 +3646,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -3657,8 +3657,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3667,7 +3667,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -3678,9 +3678,9 @@
       "integrity": "sha512-s/SIX6yp/5S1p8aC/NRDC1fwEb+myGIfp8/TzZz0rtAv8fzsdX7vGl3Q1TrXCsczFq8DI3CBFBCySPClfBSdbg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "is-es2016-keyword": "1.0.0",
-        "js-tokens": "3.0.2"
+        "chalk": "^2.4.0",
+        "is-es2016-keyword": "^1.0.0",
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3689,7 +3689,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3698,9 +3698,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -3715,7 +3715,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -3726,8 +3726,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -3736,7 +3736,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3751,7 +3751,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.3"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "http-errors": {
@@ -3759,10 +3759,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -3771,9 +3771,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -3782,7 +3782,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -3808,8 +3808,8 @@
       "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "2.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
       }
     },
     "imurmurhash": {
@@ -3830,17 +3830,16 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -3860,19 +3859,19 @@
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.3.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.1.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "5.5.11",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^5.5.2",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3893,8 +3892,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3903,7 +3902,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -3914,7 +3913,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -3928,36 +3927,35 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.2.2.tgz",
       "integrity": "sha512-g+ShTQYLsCcOUkNOK6CCEZbj3aRDVPw3WOwXk+LxlUKvuS9ujEqP2MppBHyRVYrNNFW/vcPaTBUZ2ctGNSiOCA==",
       "requires": {
-        "bluebird": "3.5.1",
-        "cluster-key-slot": "1.0.8",
-        "debug": "2.6.9",
-        "denque": "1.2.3",
+        "bluebird": "^3.3.4",
+        "cluster-key-slot": "^1.0.6",
+        "debug": "^2.6.9",
+        "denque": "^1.1.0",
         "flexbuffer": "0.0.6",
-        "lodash.assign": "4.2.0",
-        "lodash.bind": "4.2.1",
-        "lodash.clone": "4.5.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.defaults": "4.2.0",
-        "lodash.difference": "4.5.0",
-        "lodash.flatten": "4.4.0",
-        "lodash.foreach": "4.5.0",
-        "lodash.isempty": "4.4.0",
-        "lodash.keys": "4.2.0",
-        "lodash.noop": "3.0.1",
-        "lodash.partial": "4.2.1",
-        "lodash.pick": "4.4.0",
-        "lodash.sample": "4.2.1",
-        "lodash.shuffle": "4.2.0",
-        "lodash.values": "4.3.0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
+        "lodash.assign": "^4.2.0",
+        "lodash.bind": "^4.2.1",
+        "lodash.clone": "^4.5.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.keys": "^4.2.0",
+        "lodash.noop": "^3.0.1",
+        "lodash.partial": "^4.2.1",
+        "lodash.pick": "^4.4.0",
+        "lodash.sample": "^4.2.1",
+        "lodash.shuffle": "^4.2.0",
+        "lodash.values": "^4.3.0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.4.0"
       }
     },
     "ipaddr.js": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.7.0.tgz",
-      "integrity": "sha1-IgbtM0r8MuAf7T7oOLayUhBoudI=",
-      "dev": true
+      "integrity": "sha1-IgbtM0r8MuAf7T7oOLayUhBoudI="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -3965,7 +3963,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-arrayish": {
@@ -3986,7 +3984,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -4001,7 +3999,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -4010,7 +4008,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-date-object": {
@@ -4025,9 +4023,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -4056,7 +4054,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -4065,7 +4063,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator-fn": {
@@ -4080,8 +4078,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-npm": {
@@ -4096,7 +4094,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -4117,7 +4115,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -4126,7 +4124,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-object": {
@@ -4135,7 +4133,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-promise": {
@@ -4156,7 +4154,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -4230,18 +4228,18 @@
       "integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "compare-versions": "3.3.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.2.1",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-report": "1.1.4",
-        "istanbul-lib-source-maps": "1.2.5",
-        "istanbul-reports": "1.3.0",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "compare-versions": "^3.1.0",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.2.0",
+        "istanbul-lib-hook": "^1.2.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "istanbul-lib-report": "^1.1.4",
+        "istanbul-lib-source-maps": "^1.2.4",
+        "istanbul-reports": "^1.3.0",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       },
       "dependencies": {
         "async": {
@@ -4250,7 +4248,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.17.10"
           }
         }
       }
@@ -4267,7 +4265,7 @@
       "integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
       "dev": true,
       "requires": {
-        "append-transform": "1.0.0"
+        "append-transform": "^1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -4276,13 +4274,13 @@
       "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "semver": "5.5.0"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -4291,10 +4289,10 @@
       "integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -4309,7 +4307,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -4320,11 +4318,11 @@
       "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "istanbul-lib-coverage": "1.2.0",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "debug": {
@@ -4344,7 +4342,7 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11"
+        "handlebars": "^4.0.3"
       }
     },
     "jest": {
@@ -4353,8 +4351,8 @@
       "integrity": "sha1-E1XNeS84zyD7pNoC3dt8oU2UhLU=",
       "dev": true,
       "requires": {
-        "import-local": "1.0.0",
-        "jest-cli": "23.3.0"
+        "import-local": "^1.0.0",
+        "jest-cli": "^23.3.0"
       }
     },
     "jest-changed-files": {
@@ -4363,7 +4361,7 @@
       "integrity": "sha1-oUWm5LZtASn8fJnO4TTck3pkPZw=",
       "dev": true,
       "requires": {
-        "throat": "4.1.0"
+        "throat": "^4.0.0"
       }
     },
     "jest-cli": {
@@ -4372,42 +4370,42 @@
       "integrity": "sha1-MH6b53M0Q7eJqCedaUBU0FGp5eI=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.3.0",
-        "exit": "0.1.2",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "import-local": "1.0.0",
-        "is-ci": "1.1.0",
-        "istanbul-api": "1.3.1",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-instrument": "1.10.1",
-        "istanbul-lib-source-maps": "1.2.5",
-        "jest-changed-files": "23.2.0",
-        "jest-config": "23.3.0",
-        "jest-environment-jsdom": "23.3.0",
-        "jest-get-type": "22.4.3",
-        "jest-haste-map": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-regex-util": "23.3.0",
-        "jest-resolve-dependencies": "23.3.0",
-        "jest-runner": "23.3.0",
-        "jest-runtime": "23.3.0",
-        "jest-snapshot": "23.3.0",
-        "jest-util": "23.3.0",
-        "jest-validate": "23.3.0",
-        "jest-watcher": "23.2.0",
-        "jest-worker": "23.2.0",
-        "micromatch": "3.1.10",
-        "node-notifier": "5.2.1",
-        "prompts": "0.1.11",
-        "realpath-native": "1.0.1",
-        "rimraf": "2.6.2",
-        "slash": "1.0.0",
-        "string-length": "2.0.0",
-        "strip-ansi": "4.0.0",
-        "which": "1.3.0",
-        "yargs": "11.1.0"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "import-local": "^1.0.0",
+        "is-ci": "^1.0.10",
+        "istanbul-api": "^1.3.1",
+        "istanbul-lib-coverage": "^1.2.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "istanbul-lib-source-maps": "^1.2.4",
+        "jest-changed-files": "^23.2.0",
+        "jest-config": "^23.3.0",
+        "jest-environment-jsdom": "^23.3.0",
+        "jest-get-type": "^22.1.0",
+        "jest-haste-map": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve-dependencies": "^23.3.0",
+        "jest-runner": "^23.3.0",
+        "jest-runtime": "^23.3.0",
+        "jest-snapshot": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "jest-validate": "^23.3.0",
+        "jest-watcher": "^23.2.0",
+        "jest-worker": "^23.2.0",
+        "micromatch": "^3.1.10",
+        "node-notifier": "^5.2.1",
+        "prompts": "^0.1.9",
+        "realpath-native": "^1.0.0",
+        "rimraf": "^2.5.4",
+        "slash": "^1.0.0",
+        "string-length": "^2.0.0",
+        "strip-ansi": "^4.0.0",
+        "which": "^1.2.12",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4422,7 +4420,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4433,19 +4431,19 @@
       "integrity": "sha1-u01Ttw+VAPr933GNImq7U7E7gyM=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-jest": "23.2.0",
-        "chalk": "2.3.0",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "23.3.0",
-        "jest-environment-node": "23.3.0",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "23.3.0",
-        "jest-regex-util": "23.3.0",
-        "jest-resolve": "23.2.0",
-        "jest-util": "23.3.0",
-        "jest-validate": "23.3.0",
-        "pretty-format": "23.2.0"
+        "babel-core": "^6.0.0",
+        "babel-jest": "^23.2.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^23.3.0",
+        "jest-environment-node": "^23.3.0",
+        "jest-get-type": "^22.1.0",
+        "jest-jasmine2": "^23.3.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve": "^23.2.0",
+        "jest-util": "^23.3.0",
+        "jest-validate": "^23.3.0",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-diff": {
@@ -4454,10 +4452,10 @@
       "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "diff": "3.5.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-docblock": {
@@ -4466,7 +4464,7 @@
       "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
       "dev": true,
       "requires": {
-        "detect-newline": "2.1.0"
+        "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
@@ -4475,8 +4473,8 @@
       "integrity": "sha1-pAD4HIVwg/UMT1M5mxCfEgI/sZ0=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-environment-jsdom": {
@@ -4485,9 +4483,9 @@
       "integrity": "sha1-GQRX+RyeYVRUxBhgVgZdtu16Tio=",
       "dev": true,
       "requires": {
-        "jest-mock": "23.2.0",
-        "jest-util": "23.3.0",
-        "jsdom": "11.11.0"
+        "jest-mock": "^23.2.0",
+        "jest-util": "^23.3.0",
+        "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
@@ -4496,8 +4494,8 @@
       "integrity": "sha1-Ho3yHIR6pdA7dlc/DcFvzeUDTDI=",
       "dev": true,
       "requires": {
-        "jest-mock": "23.2.0",
-        "jest-util": "23.3.0"
+        "jest-mock": "^23.2.0",
+        "jest-util": "^23.3.0"
       }
     },
     "jest-get-type": {
@@ -4512,13 +4510,13 @@
       "integrity": "sha1-0Qy6wAfGlZSMjvGCGisu0tTy1Ng=",
       "dev": true,
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "23.2.0",
-        "jest-serializer": "23.0.1",
-        "jest-worker": "23.2.0",
-        "micromatch": "3.1.10",
-        "sane": "2.5.2"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^23.2.0",
+        "jest-serializer": "^23.0.1",
+        "jest-worker": "^23.2.0",
+        "micromatch": "^3.1.10",
+        "sane": "^2.0.0"
       }
     },
     "jest-jasmine2": {
@@ -4527,17 +4525,17 @@
       "integrity": "sha1-qHBrqsI8ihMNWqjvVGSp1JCW0bU=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "co": "4.6.0",
-        "expect": "23.3.0",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "23.2.0",
-        "jest-each": "23.2.0",
-        "jest-matcher-utils": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-snapshot": "23.3.0",
-        "jest-util": "23.3.0",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^23.3.0",
+        "is-generator-fn": "^1.0.0",
+        "jest-diff": "^23.2.0",
+        "jest-each": "^23.2.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-snapshot": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-leak-detector": {
@@ -4546,7 +4544,7 @@
       "integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
       "dev": true,
       "requires": {
-        "pretty-format": "23.2.0"
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-matcher-utils": {
@@ -4555,9 +4553,9 @@
       "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "22.4.3",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-message-util": {
@@ -4566,11 +4564,11 @@
       "integrity": "sha1-vAexHOxpcftd2d4t+2DrwiFQwWA=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.52",
-        "chalk": "2.3.0",
-        "micromatch": "3.1.10",
-        "slash": "1.0.0",
-        "stack-utils": "1.0.1"
+        "@babel/code-frame": "^7.0.0-beta.35",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^1.0.0",
+        "stack-utils": "^1.0.1"
       }
     },
     "jest-mock": {
@@ -4591,9 +4589,9 @@
       "integrity": "sha1-oHkK1aO5kAKrTb/L+Nni1qabPZk=",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.3",
-        "chalk": "2.3.0",
-        "realpath-native": "1.0.1"
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "realpath-native": "^1.0.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -4602,8 +4600,8 @@
       "integrity": "sha1-hETTsLEoi4CGTYgB/1C0Sk1pXR0=",
       "dev": true,
       "requires": {
-        "jest-regex-util": "23.3.0",
-        "jest-snapshot": "23.3.0"
+        "jest-regex-util": "^23.3.0",
+        "jest-snapshot": "^23.3.0"
       }
     },
     "jest-runner": {
@@ -4612,19 +4610,19 @@
       "integrity": "sha1-BMfkWKYXUBpIddsNf/vg48vUO/s=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.3.0",
-        "jest-docblock": "23.2.0",
-        "jest-haste-map": "23.2.0",
-        "jest-jasmine2": "23.3.0",
-        "jest-leak-detector": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-runtime": "23.3.0",
-        "jest-util": "23.3.0",
-        "jest-worker": "23.2.0",
-        "source-map-support": "0.5.6",
-        "throat": "4.1.0"
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^23.3.0",
+        "jest-docblock": "^23.2.0",
+        "jest-haste-map": "^23.2.0",
+        "jest-jasmine2": "^23.3.0",
+        "jest-leak-detector": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-runtime": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "jest-worker": "^23.2.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -4639,8 +4637,8 @@
           "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.0",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           }
         }
       }
@@ -4651,27 +4649,27 @@
       "integrity": "sha1-SGWqtM7/gvnOxjNf164UIswd598=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-plugin-istanbul": "4.1.6",
-        "chalk": "2.3.0",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.3.0",
-        "jest-haste-map": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-regex-util": "23.3.0",
-        "jest-resolve": "23.2.0",
-        "jest-snapshot": "23.3.0",
-        "jest-util": "23.3.0",
-        "jest-validate": "23.3.0",
-        "micromatch": "3.1.10",
-        "realpath-native": "1.0.1",
-        "slash": "1.0.0",
+        "babel-core": "^6.0.0",
+        "babel-plugin-istanbul": "^4.1.6",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "exit": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^23.3.0",
+        "jest-haste-map": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-regex-util": "^23.3.0",
+        "jest-resolve": "^23.2.0",
+        "jest-snapshot": "^23.3.0",
+        "jest-util": "^23.3.0",
+        "jest-validate": "^23.3.0",
+        "micromatch": "^3.1.10",
+        "realpath-native": "^1.0.0",
+        "slash": "^1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "11.1.0"
+        "write-file-atomic": "^2.1.0",
+        "yargs": "^11.0.0"
       }
     },
     "jest-serializer": {
@@ -4686,17 +4684,17 @@
       "integrity": "sha1-/E6fgeRUMtEFB+J/ULzmD0TYFCQ=",
       "dev": true,
       "requires": {
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "chalk": "2.3.0",
-        "jest-diff": "23.2.0",
-        "jest-matcher-utils": "23.2.0",
-        "jest-message-util": "23.3.0",
-        "jest-resolve": "23.2.0",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "23.2.0",
-        "semver": "5.5.0"
+        "babel-traverse": "^6.0.0",
+        "babel-types": "^6.0.0",
+        "chalk": "^2.0.1",
+        "jest-diff": "^23.2.0",
+        "jest-matcher-utils": "^23.2.0",
+        "jest-message-util": "^23.3.0",
+        "jest-resolve": "^23.2.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^23.2.0",
+        "semver": "^5.5.0"
       }
     },
     "jest-util": {
@@ -4705,14 +4703,14 @@
       "integrity": "sha1-efNbsMMBAO9hHZY+5riPjthzqB0=",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.3.0",
-        "graceful-fs": "4.1.11",
-        "is-ci": "1.1.0",
-        "jest-message-util": "23.3.0",
-        "mkdirp": "0.5.1",
-        "slash": "1.0.0",
-        "source-map": "0.6.1"
+        "callsites": "^2.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.11",
+        "is-ci": "^1.0.10",
+        "jest-message-util": "^23.3.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "callsites": {
@@ -4735,10 +4733,10 @@
       "integrity": "sha1-1Jvqaq2YwwrNLLtUJDR5igzBP3Y=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0",
-        "jest-get-type": "22.4.3",
-        "leven": "2.1.0",
-        "pretty-format": "23.2.0"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^23.2.0"
       }
     },
     "jest-watcher": {
@@ -4747,9 +4745,9 @@
       "integrity": "sha1-Z46FKJbpGenZoOtLi68a4nliDqk=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.3.0",
-        "string-length": "2.0.0"
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
@@ -4758,7 +4756,7 @@
       "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
       "dev": true,
       "requires": {
-        "merge-stream": "1.0.1"
+        "merge-stream": "^1.0.1"
       }
     },
     "js-tokens": {
@@ -4773,8 +4771,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -4790,32 +4788,32 @@
       "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "5.7.1",
-        "acorn-globals": "4.1.0",
-        "array-equal": "1.0.0",
-        "cssom": "0.3.4",
-        "cssstyle": "0.3.1",
-        "data-urls": "1.0.0",
-        "domexception": "1.0.1",
-        "escodegen": "1.10.0",
-        "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.3.0",
-        "nwsapi": "2.0.4",
+        "abab": "^1.0.4",
+        "acorn": "^5.3.0",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.3.1 < 0.4.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.0",
+        "escodegen": "^1.9.0",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.2.0",
+        "nwsapi": "^2.0.0",
         "parse5": "4.0.0",
-        "pn": "1.1.0",
-        "request": "2.87.0",
-        "request-promise-native": "1.0.5",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.4.3",
-        "w3c-hr-time": "1.0.1",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.3",
-        "whatwg-mimetype": "2.1.0",
-        "whatwg-url": "6.5.0",
-        "ws": "4.1.0",
-        "xml-name-validator": "3.0.0"
+        "pn": "^1.1.0",
+        "request": "^2.83.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.3",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^4.0.0",
+        "xml-name-validator": "^3.0.0"
       }
     },
     "jsesc": {
@@ -4859,15 +4857,15 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
       "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
       "requires": {
-        "jws": "3.1.5",
-        "lodash.includes": "4.3.0",
-        "lodash.isboolean": "3.0.3",
-        "lodash.isinteger": "4.0.4",
-        "lodash.isnumber": "3.0.3",
-        "lodash.isplainobject": "4.0.6",
-        "lodash.isstring": "4.0.1",
-        "lodash.once": "4.1.1",
-        "ms": "2.1.1"
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1"
       },
       "dependencies": {
         "ms": {
@@ -4896,7 +4894,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
@@ -4904,8 +4902,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "1.1.6",
-        "safe-buffer": "5.1.1"
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -4914,7 +4912,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "latest-version": {
@@ -4923,7 +4921,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lazy-cache": {
@@ -4939,7 +4937,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -4951,8 +4949,7 @@
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-      "dev": true
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "levn": {
       "version": "0.3.0",
@@ -4960,8 +4957,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lie": {
@@ -4969,7 +4966,7 @@
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
-        "immediate": "3.0.6"
+        "immediate": "~3.0.5"
       }
     },
     "load-json-file": {
@@ -4978,11 +4975,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -4991,7 +4988,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -5010,8 +5007,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -5152,7 +5149,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.0"
+        "chalk": "^2.0.1"
       }
     },
     "log-update": {
@@ -5161,8 +5158,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -5177,7 +5174,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -5192,8 +5189,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         }
       }
@@ -5210,7 +5207,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -5219,8 +5216,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -5235,8 +5232,8 @@
       "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "lru-queue": {
@@ -5245,7 +5242,7 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.45"
+        "es5-ext": "~0.10.2"
       }
     },
     "make-dir": {
@@ -5254,7 +5251,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5271,7 +5268,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-cache": {
@@ -5292,7 +5289,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "media-typer": {
@@ -5306,7 +5303,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memoizee": {
@@ -5315,13 +5312,13 @@
       "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.45",
-        "es6-weak-map": "0.1.4",
-        "event-emitter": "0.3.5",
-        "lru-queue": "0.1.0",
-        "next-tick": "0.2.2",
-        "timers-ext": "0.1.5"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.11",
+        "es6-weak-map": "~0.1.4",
+        "event-emitter": "~0.3.4",
+        "lru-queue": "0.1",
+        "next-tick": "~0.2.2",
+        "timers-ext": "0.1"
       },
       "dependencies": {
         "next-tick": {
@@ -5338,16 +5335,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -5370,7 +5367,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "micromatch": {
@@ -5379,19 +5376,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5417,7 +5414,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
@@ -5430,9 +5427,8 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -5446,8 +5442,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -5456,7 +5452,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -5473,7 +5469,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/moleculer/-/moleculer-0.13.0.tgz",
       "integrity": "sha512-32EbunZ7Cg2PTMR+wCtUm/7i4rAbpCsRkkkFBcKNZ8xSp0d+sq8xuDuVAzGb/qpUQyA9yBN+QHril40yN6CW6w==",
-      "dev": true,
       "requires": {
         "args": "5.0.0",
         "bluebird": "3.5.1",
@@ -5490,35 +5485,31 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5539,7 +5530,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5547,9 +5538,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -5567,7 +5558,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5578,7 +5569,7 @@
       "integrity": "sha512-Kwz7unrp6ba8y1hJZ3GNLEf7lHSrw+bPm5jgEHyEb3d1kdnVGDWck8QFPXyPEJsbOmJ+R0cS97xf/CqyLBszRA==",
       "requires": {
         "bluebird": "3.5.1",
-        "lodash": "4.17.10",
+        "lodash": "^4.17.5",
         "nedb": "1.8.0"
       }
     },
@@ -5619,7 +5610,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5628,9 +5619,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "cli-spinners": {
@@ -5651,12 +5642,12 @@
           "integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-spinners": "1.3.1",
-            "log-symbols": "2.2.0",
-            "strip-ansi": "4.0.0",
-            "wcwidth": "1.0.1"
+            "chalk": "^2.3.1",
+            "cli-cursor": "^2.1.0",
+            "cli-spinners": "^1.1.0",
+            "log-symbols": "^2.2.0",
+            "strip-ansi": "^4.0.0",
+            "wcwidth": "^1.0.1"
           }
         },
         "strip-ansi": {
@@ -5665,7 +5656,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -5674,7 +5665,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -5713,15 +5704,14 @@
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.5.tgz",
       "integrity": "sha512-4A1nx/xAU5d/NPICjiyzVxzNrIdJQQsYRe3xQkV1O638t+fHHfAOLK+SQagqGnu1m0aeSxb1ixp/P0FGSQWIGA==",
       "requires": {
-        "bson": "1.0.9",
-        "require_optional": "1.0.1"
+        "bson": "~1.0.4",
+        "require_optional": "^1.0.1"
       }
     },
     "mri": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.1.tgz",
-      "integrity": "sha1-haom09ru7t+A3FmEr5XMXKXK2fE=",
-      "dev": true
+      "integrity": "sha1-haom09ru7t+A3FmEr5XMXKXK2fE="
     },
     "ms": {
       "version": "2.0.0",
@@ -5737,7 +5727,9 @@
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5745,17 +5737,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -5764,14 +5756,6 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
-      }
-    },
-    "nats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nats/-/nats-1.0.0.tgz",
-      "integrity": "sha512-OUGyBCgmJEYYFnGTXP48OPTwuybq/K4udgygUxjMIYnc2F6Va/1ElHlVVr1tmjSme4f5KwCFWVpHoN5+s2yBiw==",
-      "requires": {
-        "nuid": "1.0.0"
       }
     },
     "natural-compare": {
@@ -5787,9 +5771,9 @@
       "requires": {
         "async": "0.2.10",
         "binary-search-tree": "0.2.5",
-        "localforage": "1.7.2",
-        "mkdirp": "0.5.1",
-        "underscore": "1.4.4"
+        "localforage": "^1.3.0",
+        "mkdirp": "~0.5.1",
+        "underscore": "~1.4.4"
       }
     },
     "next-tick": {
@@ -5810,7 +5794,7 @@
       "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "dev": true,
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-int64": {
@@ -5831,10 +5815,10 @@
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.5.0",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.4.1",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
       }
     },
     "normalize-package-data": {
@@ -5843,10 +5827,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -5855,7 +5839,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-check": {
@@ -5864,31 +5848,31 @@
       "integrity": "sha512-dwcM2+tfeaqZHIbnp/bsMFepu8mGdH+REnax3KnZowKj7oTPQXrwfOC4v/yk3eMtM0JHhzU8yItTAZgY3X+qJg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "callsite-record": "3.2.2",
-        "chalk": "1.1.3",
-        "co": "4.6.0",
-        "depcheck": "0.6.9",
-        "execa": "0.2.2",
-        "giturl": "1.0.0",
-        "global-modules": "1.0.0",
-        "globby": "4.1.0",
-        "inquirer": "0.12.0",
-        "is-ci": "1.1.0",
-        "lodash": "4.17.10",
-        "meow": "3.7.0",
-        "minimatch": "3.0.4",
-        "node-emoji": "1.8.1",
-        "ora": "0.2.3",
-        "package-json": "4.0.1",
-        "path-exists": "2.1.0",
-        "pkg-dir": "1.0.0",
-        "semver": "5.5.0",
-        "semver-diff": "2.1.0",
-        "text-table": "0.2.0",
-        "throat": "2.0.2",
-        "update-notifier": "2.5.0",
-        "xtend": "4.0.1"
+        "babel-runtime": "^6.6.1",
+        "callsite-record": "^3.0.0",
+        "chalk": "^1.1.3",
+        "co": "^4.6.0",
+        "depcheck": "^0.6.3",
+        "execa": "^0.2.2",
+        "giturl": "^1.0.0",
+        "global-modules": "^1.0.0",
+        "globby": "^4.0.0",
+        "inquirer": "^0.12.0",
+        "is-ci": "^1.0.8",
+        "lodash": "^4.7.0",
+        "meow": "^3.7.0",
+        "minimatch": "^3.0.2",
+        "node-emoji": "^1.0.3",
+        "ora": "^0.2.1",
+        "package-json": "^4.0.1",
+        "path-exists": "^2.1.0",
+        "pkg-dir": "^1.0.0",
+        "semver": "^5.0.1",
+        "semver-diff": "^2.0.0",
+        "text-table": "^0.2.0",
+        "throat": "^2.0.2",
+        "update-notifier": "^2.1.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -5909,11 +5893,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -5922,7 +5906,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "execa": {
@@ -5931,11 +5915,11 @@
           "integrity": "sha1-4urUcsLDGq1vc/GslW7vReEjIMs=",
           "dev": true,
           "requires": {
-            "cross-spawn-async": "2.2.5",
-            "npm-run-path": "1.0.0",
-            "object-assign": "4.1.1",
-            "path-key": "1.0.0",
-            "strip-eof": "1.0.0"
+            "cross-spawn-async": "^2.1.1",
+            "npm-run-path": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "path-key": "^1.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "figures": {
@@ -5944,8 +5928,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "find-up": {
@@ -5954,8 +5938,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "glob": {
@@ -5964,11 +5948,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -5977,12 +5961,12 @@
           "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "6.0.4",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^6.0.1",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "inquirer": {
@@ -5991,19 +5975,19 @@
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.10",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           }
         },
         "npm-run-path": {
@@ -6012,7 +5996,7 @@
           "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
           "dev": true,
           "requires": {
-            "path-key": "1.0.0"
+            "path-key": "^1.0.0"
           }
         },
         "onetime": {
@@ -6027,7 +6011,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-key": {
@@ -6042,7 +6026,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -6051,8 +6035,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "run-async": {
@@ -6061,7 +6045,7 @@
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.3.0"
           }
         },
         "rx-lite": {
@@ -6090,13 +6074,8 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
-    },
-    "nuid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nuid/-/nuid-1.0.0.tgz",
-      "integrity": "sha512-046ukkoG8NXjiJMpQYLpGhYJIXJlClt2rDlnubCXN1/pztO/YTD2WkhyBZsEADsUwVtVMv5UmC0B2QrT5sZiDQ=="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -6128,9 +6107,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -6139,7 +6118,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -6156,7 +6135,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.getownpropertydescriptors": {
@@ -6165,8 +6144,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.pick": {
@@ -6175,7 +6154,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "on-finished": {
@@ -6190,9 +6169,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -6201,7 +6179,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -6210,8 +6188,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -6228,12 +6206,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "ora": {
@@ -6242,10 +6220,10 @@
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "chalk": "^1.1.1",
+        "cli-cursor": "^1.0.2",
+        "cli-spinners": "^0.1.2",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6260,11 +6238,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -6273,7 +6251,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "onetime": {
@@ -6288,8 +6266,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "supports-color": {
@@ -6312,9 +6290,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -6335,7 +6313,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -6344,7 +6322,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -6359,10 +6337,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "parse-json": {
@@ -6371,7 +6349,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -6406,8 +6384,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -6433,9 +6410,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "performance-now": {
@@ -6462,7 +6439,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -6471,7 +6448,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pluralize": {
@@ -6516,8 +6493,8 @@
       "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6552,8 +6529,8 @@
       "integrity": "sha512-6ZFzPasWMEgZ/cDpQQshV/l/fWISILGjq4VctCipG6RVfaO4FAafGR8iKXSFxoHIYgPcPYuDupyLtVNc/aDG8Q==",
       "dev": true,
       "requires": {
-        "clorox": "1.0.3",
-        "sisteransi": "0.1.1"
+        "clorox": "^1.0.3",
+        "sisteransi": "^0.1.1"
       }
     },
     "pseudomap": {
@@ -6600,7 +6577,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -6611,10 +6588,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -6631,9 +6608,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -6642,8 +6619,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -6652,8 +6629,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -6662,7 +6639,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -6673,13 +6650,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -6688,8 +6665,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -6707,7 +6684,7 @@
       "integrity": "sha512-W14EcXuqUvKP8dkWkD7B95iMy77lpMnlFXbbk409bQtNCbeu0kvRE5reo+yIZ3JXxg6frbGsz2DLQ39lrCB40g==",
       "dev": true,
       "requires": {
-        "util.promisify": "1.0.0"
+        "util.promisify": "^1.0.0"
       }
     },
     "redent": {
@@ -6716,8 +6693,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "redis-commands": {
@@ -6742,8 +6719,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexp.prototype.flags": {
@@ -6752,7 +6729,7 @@
       "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2"
+        "define-properties": "^1.1.2"
       }
     },
     "regexpp": {
@@ -6767,8 +6744,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -6777,7 +6754,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.8"
+        "rc": "^1.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -6804,7 +6781,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -6813,26 +6790,26 @@
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.1",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -6847,7 +6824,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         }
       }
@@ -6858,7 +6835,7 @@
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.13.1"
       }
     },
     "request-promise-native": {
@@ -6868,8 +6845,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.4.3"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "require-directory": {
@@ -6896,8 +6873,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -6913,8 +6890,8 @@
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.5.0"
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
       }
     },
     "resolve": {
@@ -6929,7 +6906,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -6946,8 +6923,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -6967,8 +6944,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -6984,7 +6961,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -6993,7 +6970,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "rsvp": {
@@ -7008,7 +6985,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -7037,7 +7014,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -7051,15 +7028,15 @@
       "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "capture-exit": "1.2.0",
-        "exec-sh": "0.2.2",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
-        "micromatch": "3.1.10",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.3",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       },
       "dependencies": {
         "minimist": {
@@ -7087,7 +7064,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.0.3"
       }
     },
     "send": {
@@ -7096,18 +7073,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -7122,9 +7099,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -7140,10 +7117,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7152,7 +7129,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7168,7 +7145,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -7206,7 +7183,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -7221,7 +7198,7 @@
       "resolved": "https://registry.npmjs.org/slug/-/slug-0.9.1.tgz",
       "integrity": "sha1-rwj2CKfBFRa2F3iqgA3OhMUYz9o=",
       "requires": {
-        "unicode": "10.0.0"
+        "unicode": ">= 0.3.1"
       }
     },
     "snapdragon": {
@@ -7230,14 +7207,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.0"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7246,7 +7223,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -7255,7 +7232,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -7266,9 +7243,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -7277,7 +7254,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -7286,7 +7263,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -7295,7 +7272,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -7304,9 +7281,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         },
         "kind-of": {
@@ -7323,7 +7300,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       }
     },
     "source-map": {
@@ -7338,11 +7315,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.1",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -7351,7 +7328,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -7366,8 +7343,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -7382,8 +7359,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7398,7 +7375,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -7413,15 +7390,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-utils": {
@@ -7442,8 +7419,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -7452,7 +7429,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -7474,8 +7451,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7490,7 +7467,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7501,9 +7478,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.matchall": {
@@ -7512,11 +7489,11 @@
       "integrity": "sha512-WoZ+B2ypng1dp4iFLF2kmZlwwlE19gmjgKuhL1FJfDgCREWb3ye3SDVHSzLH6bxfnvYmkCxbzkmWcQZHA4P//Q==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.0",
-        "regexp.prototype.flags": "1.2.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "string_decoder": {
@@ -7525,7 +7502,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -7534,7 +7511,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -7555,7 +7532,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -7570,7 +7547,7 @@
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "symbol-observable": {
@@ -7591,12 +7568,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.2",
-        "ajv-keywords": "3.2.0",
-        "chalk": "2.3.0",
-        "lodash": "4.17.10",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7617,8 +7594,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -7627,7 +7604,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7638,7 +7615,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "test-exclude": {
@@ -7647,11 +7624,11 @@
       "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "3.1.10",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^3.1.8",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       }
     },
     "text-table": {
@@ -7684,8 +7661,8 @@
       "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.45",
-        "next-tick": "1.0.0"
+        "es5-ext": "~0.10.14",
+        "next-tick": "1"
       }
     },
     "tiny-human-time": {
@@ -7699,7 +7676,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -7720,7 +7697,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "to-regex": {
@@ -7729,10 +7706,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -7741,8 +7718,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -7751,8 +7728,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.1.28",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -7769,7 +7746,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "trim-newlines": {
@@ -7790,7 +7767,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -7806,7 +7783,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -7815,7 +7792,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "uglify-js": {
@@ -7825,9 +7802,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -7837,9 +7814,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -7868,10 +7845,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -7880,7 +7857,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -7889,10 +7866,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
@@ -7903,7 +7880,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unpipe": {
@@ -7917,8 +7894,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -7927,9 +7904,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -7963,16 +7940,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.0",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "uri-js": {
@@ -7981,7 +7958,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -7996,7 +7973,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "use": {
@@ -8005,7 +7982,7 @@
       "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "kind-of": "6.0.2"
+        "kind-of": "^6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -8028,8 +8005,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "object.getownpropertydescriptors": "2.0.3"
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
       }
     },
     "uuid": {
@@ -8044,8 +8021,8 @@
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -8054,9 +8031,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vorpal": {
@@ -8065,16 +8042,16 @@
       "integrity": "sha1-S+eypOSPj8/JzzZIxBnTEcUiFZ0=",
       "dev": true,
       "requires": {
-        "babel-polyfill": "6.26.0",
-        "chalk": "1.1.3",
-        "in-publish": "2.0.0",
+        "babel-polyfill": "^6.3.14",
+        "chalk": "^1.1.0",
+        "in-publish": "^2.0.0",
         "inquirer": "0.11.0",
-        "lodash": "4.17.10",
-        "log-update": "1.0.2",
-        "minimist": "1.2.0",
-        "node-localstorage": "0.6.0",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "lodash": "^4.5.1",
+        "log-update": "^1.0.2",
+        "minimist": "^1.2.0",
+        "node-localstorage": "^0.6.0",
+        "strip-ansi": "^3.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -8095,11 +8072,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-cursor": {
@@ -8108,7 +8085,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "cli-width": {
@@ -8123,8 +8100,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "inquirer": {
@@ -8133,18 +8110,18 @@
           "integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "1.1.1",
-            "figures": "1.7.0",
-            "lodash": "3.10.1",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^1.0.1",
+            "figures": "^1.3.5",
+            "lodash": "^3.3.1",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           },
           "dependencies": {
             "lodash": {
@@ -8173,8 +8150,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "run-async": {
@@ -8183,7 +8160,7 @@
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.3.0"
           }
         },
         "supports-color": {
@@ -8200,7 +8177,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "0.1.2"
+        "browser-process-hrtime": "^0.1.2"
       }
     },
     "walkdir": {
@@ -8215,7 +8192,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -8224,8 +8201,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.2",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -8242,7 +8219,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3"
+        "defaults": "^1.0.3"
       }
     },
     "webidl-conversions": {
@@ -8280,9 +8257,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
@@ -8291,7 +8268,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -8306,7 +8283,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8327,8 +8304,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -8337,7 +8314,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8361,15 +8338,14 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -8377,7 +8353,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -8386,9 +8362,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -8397,8 +8373,8 @@
       "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0"
       }
     },
     "xdg-basedir": {
@@ -8437,18 +8413,18 @@
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^9.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8463,9 +8439,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -8480,8 +8456,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -8490,7 +8466,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -8501,7 +8477,7 @@
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/conduit/package.json
+++ b/conduit/package.json
@@ -25,7 +25,7 @@
     "npm-check": "5.7.1"
   },
   "dependencies": {
-    "bcrypt": "2.0.1",
+    "bcrypt": "^3.0.2",
     "ioredis": "3.2.2",
     "jsonwebtoken": "8.3.0",
     "lodash": "4.17.10",


### PR DESCRIPTION
Running the conduit service showed this error: ERROR: Service 'api' failed to build: The command '/bin/sh -c npm install --silent --progress=false --production' returned a non-zero code: 6

Looking onto the npm install errors, node-pre-gyp was failing due to an older version of bcrypt. Updating the version of bcrypt unblocked the error and is now running properly. 

Resolves #12 